### PR TITLE
🔧 direnv連携をscripts/ghxから削除

### DIFF
--- a/.ai/dev-env.md
+++ b/.ai/dev-env.md
@@ -27,6 +27,6 @@
 - GitHub操作は `gh` 必須ではない
 - `gh` / GitHub REST API / GitHub GraphQL API のいずれを使ってもよい
 - `gh` を使う場合は `scripts/ghx ...` を使う
-- `scripts/ghx` は、`direnv` が使える環境ではプロジェクトルートで `direnv exec` を実行し、`direnv` 未インストール時は警告付きで `gh` にフォールバックする
-- 認証切り替えが必要な環境では、`gh auth` に依存せずAPIトークン利用を優先してよい
+- `scripts/ghx` の内部実装への依存を運用ルールとして固定しない
+- 認証切り替えが必要な環境では、CLIのログイン状態に依存せずAPIトークン利用を優先してよい
 - どの手段でも、Issue/PR/コメント/ラベルの結果が同等であることを優先する

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 - レビュー結果は対象GitHub Issueコメントに記録する
 - `/review-verify` は対象Issueのレビューコメントを検証し、採用した指摘のみ修正する
 - 修正内容・進行状況・手順書・計画・レビュー観点は GitHub Issues に集約し、Issue単位worktree + 小PRで進める
-- GitHub CLI を使う場合は `scripts/ghx ...` を使う。`scripts/ghx` は `direnv` 連携とフォールバックを内部で処理し、PR操作・レビューコメント記録にも同ルールを適用する
+- GitHub CLI を使う場合は `scripts/ghx ...` を使う。PR操作・レビューコメント記録にも同ルールを適用する
 
 ## 必読ドキュメント（常時）
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 - レビュー結果は対象GitHub Issueコメントに記録する
 - `/review-verify <issue-number>` または `/rv <issue-number>` で採用指摘のみ修正する
 - 修正内容・進行状況・手順書・計画・レビュー観点は GitHub Issues に集約し、Issue単位worktree + 小PRで進める
-- GitHub CLI を使う場合は `scripts/ghx ...` を使う。`scripts/ghx` は `direnv` 連携とフォールバックを内部で処理し、PR操作・レビューコメント記録にも同ルールを適用する
+- GitHub CLI を使う場合は `scripts/ghx ...` を使う。PR操作・レビューコメント記録にも同ルールを適用する
 
 ## 必読ドキュメント
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ Claude Code の組み込みエージェント、またはユーザーディレ�
 - `/commit` or `/c`: 確認付きコミット
 - `/commit!` or `/c!`: 即時コミット
 
-## gh と direnv の使い方
+## scripts/ghx の使い方
 
-- `gh` 実行は `scripts/ghx ...` を推奨する
-- `scripts/ghx` は内部で、`direnv` が使える場合にプロジェクトルートで `direnv exec` を実行する
-- `direnv` 未インストール時は警告を表示し、`gh` にフォールバックする
+- GitHub CLI 実行は `scripts/ghx ...` を推奨する
+- `scripts/ghx` のエラー出力に従って不足前提を解消する
 - 実行例: `scripts/ghx issue list`
 - 実行例: `scripts/ghx pr status`
 - 実行例: `scripts/ghx issue comment 9 --body "..."`

--- a/scripts/ghx
+++ b/scripts/ghx
@@ -6,17 +6,4 @@ if ! command -v gh >/dev/null 2>&1; then
   exit 127
 fi
 
-if command -v direnv >/dev/null 2>&1; then
-  project_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-  exec direnv exec "$project_root" gh "$@" 2> >(
-    while IFS= read -r line; do
-      case "$line" in
-        *"direnv: loading "*) ;;
-        *) printf '%s\n' "$line" >&2 ;;
-      esac
-    done
-  )
-fi
-
-echo "warning: direnv is not installed; running gh without direnv" >&2
 exec gh "$@"


### PR DESCRIPTION
## 概要

Issue #18 に基づき、`scripts/ghx` から `direnv` 連携コードを削除し、GitHub CLI運用のルール文書を整合させました。`scripts/ghx` の内部実装への依存を運用ルール化せず、より柔軟な運用を可能にします。

## 変更内容

- `scripts/ghx`: `direnv exec` 分岐と警告メッセージを削除、常に `gh` を直接実行するよう簡素化
- `README.md`: 見出しを「`gh と direnv の使い方」から「`scripts/ghx の使い方」に変更、`direnv` 言及を削除
- `.ai/dev-env.md`: `scripts/ghx` の内部実装説明を削除、内部実装への依存を運用ルール化しないことを明記
- `AGENTS.md` / `CLAUDE.md`: `scripts/ghx` 説明から `direnv` 連携とフォールバック処理の記述を削除

## テスト手順

- `scripts/ghx --version` で `gh` 実行可能を確認（実施済み）
- 各ファイルで `direnv` キーワードの残存を確認（実施済み）

## 影響範囲

- GitHub CLI の実行方法に関するドキュメント全体
- 開発環境の構築手順に関する記述
- ユーザーが新たに `direnv` の依存を前提にせず `scripts/ghx` を使用可能

## チェックリスト

- [x] コミットメッセージが規約に準拠
- [x] ドキュメント変更が日本語で記述
- [x] `scripts/ghx` の動作確認（実行可能）
- [x] レビュー完了（指摘なし）

Closes #18