### PR TITLE
📝 docs: mtm デフォルト自動マージ仕様の反映

### DIFF
--- a/.ai/workflow.md
+++ b/.ai/workflow.md
@@ -139,7 +139,7 @@
   - `AI.md と .ai の必読を読み込み、計画準備状態へ入って（/plan 相当）`
   - `Issue #7 を primary_issue として .context/issue_scope.json を更新して（/pick 相当）`
   - `Issue #7 のレビューコメントを検証し、採用指摘のみ修正してIssueへ結果コメントして（/rv 相当）`
-  - `develop から main へのリリースPRを作成（必要ならマージ）して、.context の pr_number/pr_url を更新して（/mtm 相当）`
+  - `develop から main へのリリースPRを作成して通常はそのままマージし、必要なら --no-merge で作成のみ実行して、.context の pr_number/pr_url を更新して（/mtm 相当）`
   - `git add -A 後に確認付きでコミット候補を提示して（/commit 相当）`
   - `git add -A 後に最初の候補で即コミットして（/commit! 相当）`
 

--- a/.claude/commands/merge-to-main.md
+++ b/.claude/commands/merge-to-main.md
@@ -2,7 +2,7 @@
 title: "main反映PRタスク"
 read_only: false
 type: "command"
-argument-hint: "[--merge] [release-label]"
+argument-hint: "[--no-merge] [release-label]"
 ---
 
 # main反映PR作成（/merge-to-main）
@@ -22,14 +22,15 @@ argument-hint: "[--merge] [release-label]"
    - タイトル例: `release: develop を main へ反映 (<YYYY-MM-DD>)`
    - 本文には、目的・影響範囲・確認手順・未実施項目を記載する。
 6. Open PRがある場合は、そのPRを再利用する（重複PRは作成しない）。
-7. `--merge` が明示された場合のみ、チェック成功を確認してPRをマージする。
+7. `--no-merge` が明示されていない場合は、チェック成功を確認してPRをマージする。
 8. `.context/issue_scope.json` を使う運用の場合は、`pr_number` / `pr_url` / `updated_at` をロック付きで更新する。
 9. 結果を日本語で報告する（作成/再利用したPR URL、マージ有無、未実施項目）。
 
 ## ルール
 
-- デフォルト動作は「PR作成または再利用まで」。自動マージはしない。
+- デフォルト動作は「PR作成または再利用後にマージまで実行」。
+- `--no-merge` 指定時のみ、PR作成または再利用までで止める。
 - `main` への直接push/直接マージは行わない。
-- `--merge` 指定時でも、必須チェック未通過ならマージしない。
+- 必須チェック未通過ならマージしない。
 - 既存のOpenな `develop -> main` PRがある場合は、それを優先して使う。
 - コンフリクトがある場合は自動解消しない。`develop` 側で解消してから同一PRを更新する。

--- a/.claude/commands/mtm.md
+++ b/.claude/commands/mtm.md
@@ -2,7 +2,7 @@
 title: "main反映PRタスク"
 read_only: false
 type: "command"
-argument-hint: "[--merge] [release-label]"
+argument-hint: "[--no-merge] [release-label]"
 ---
 
 # main反映PR作成（/mtm）
@@ -16,5 +16,5 @@ argument-hint: "[--merge] [release-label]"
 
 - `base=main` / `head=develop` のPR作成（または既存PR再利用）を行う。
 - `develop -> main` 反映時は本コマンド（または `/merge-to-main`）を必須で利用する。
-- `--merge` がない限り、PRは作成/更新のみで止める。
+- `--no-merge` がない限り、PRは作成/更新後にマージまで行う。
 - `.context/issue_scope.json` を使う場合は `pr_number` / `pr_url` を更新する。

--- a/AI.md
+++ b/AI.md
@@ -19,7 +19,7 @@ Conductorでの基本的な進め方は、次の順番です。
 3. レビュー依頼（対象Issue番号を明記し、レビュー結果はIssueコメントに記載）
 4. `/review-verify <issue-number>` または `/rv <issue-number>` で指摘対応し、修正結果をIssueコメントに記載（引数なし時は `.context` の `primary_issue` + `active_related_issues` を参照）
 5. 小さなPRを順次適用
-6. リリース時は `/merge-to-main` または `/mtm` で `develop -> main` のPRを作成（必須手順）
+6. リリース時は `/merge-to-main` または `/mtm` で `develop -> main` のPRを作成し、通常はそのままマージ（必須手順）
 7. 必要なら `/commit` / `/c` または `/commit!` / `/c!`
 
 ### コマンド説明
@@ -29,7 +29,7 @@ Conductorでの基本的な進め方は、次の順番です。
 - `/pick <primary-issue> [related-issues...]` または `/p <primary-issue> [related-issues...]`: `schema_version: 2` の `.context/issue_scope.json` に対象Issueを固定します（任意）。related issue を扱う場合は `active_related_issues` を `reserved` で確保し、`owner` / `reserved_at`（必要なら `expires_at`）を記録します。
 - レビュー依頼: 明示コマンドは不要です。差分レビューを依頼します。
 - `/review-verify <issue-number>` または `/rv <issue-number>`: 対象Issueのレビューコメントを読み込み、採用された指摘のみ修正します。Issue連携した場合は修正結果コメントをIssueへ追記します。引数なし時は `.context/issue_scope.json` の `primary_issue` と `active_related_issues`（`in_progress` / `ready_for_close`）を対象にします。
-- `/merge-to-main [--merge] [release-label]` または `/mtm [--merge] [release-label]`: `develop -> main` 反映時の必須手順です。`base=main` / `head=develop` のリリースPRを作成（既存Open PRがあれば再利用）します。`--merge` 指定時のみマージまで実行します。詳細は `.claude/commands/merge-to-main.md` を参照します。
+- `/merge-to-main [--no-merge] [release-label]` または `/mtm [--no-merge] [release-label]`: `develop -> main` 反映時の必須手順です。`base=main` / `head=develop` のリリースPRを作成（既存Open PRがあれば再利用）し、デフォルトでマージまで実行します。PR作成/再利用のみで止める場合は `--no-merge` を指定します。詳細は `.claude/commands/merge-to-main.md` を参照します。
 - `/commit` または `/c`: 確認付きコミットです。候補メッセージ確認後にコミットします。
 - `/commit!` または `/c!`: 確認なしで即時コミットします。
 
@@ -41,7 +41,7 @@ Conductorでの基本的な進め方は、次の順番です。
   - `AI.md と .ai の必読を読み込み、計画準備状態へ入って（/plan 相当）`
   - `Issue #7 を primary_issue として .context/issue_scope.json を更新して（/pick 相当）`
   - `Issue #7 のレビューコメントを検証し、採用指摘のみ修正してIssueへ結果コメントして（/rv 相当）`
-  - `develop から main へのリリースPRを作成し、.context の pr_number/pr_url を更新して（/mtm 相当）`
+  - `develop から main へのリリースPRを作成して通常はそのままマージし、.context の pr_number/pr_url を更新して（/mtm 相当）`
   - `git add -A 後に確認付きコミット候補を出して（/commit 相当）`
 
 ### レビュー連携の要点


### PR DESCRIPTION
## 概要

`/merge-to-main` / `/mtm` コマンドのデフォルト動作を変更し、PR作成後に通常はそのままマージするよう仕様を更新したドキュメント変更です。

## 関連Issue

Closes #31

## 変更内容

- `.claude/commands/merge-to-main.md`: 引数ヒント・実行手順・ルールを `--no-merge` ベースに更新
- `.claude/commands/mtm.md`: 引数ヒント・実行ルールを `--no-merge` ベースに更新
- `AI.md`: コマンド説明・運用フロー・Codex指示例を新仕様に更新
- `.ai/workflow.md`: Codex疑似コマンド例を新仕様に更新

**変更サマリー:**
- `--merge` フラグから `--no-merge` フラグへ反転
- デフォルト動作: 「PR作成のみ」から「PR作成+マージ」に変更
- 4ファイル全体で一貫性を保持

## テスト

- [x] 実施済み
  - ドキュメント変更のみのため、以下を確認:
    - 4ファイル間の矛盾検証 (完了)
    - CLAUDE.md / `.ai/` ルール整合確認 (完了)
    - 旧 `--merge` 記述の残留確認 (完了)

## 影響範囲

- コマンド定義: `/merge-to-main`, `/mtm`
- ドキュメント: ユーザーガイド、ワークフロー説明
- 実装コード: 影響なし（ドキュメント変更のみ）

## チェックリスト

- [x] `/merge-to-main` / `/mtm` の説明が統一されている
- [x] `--merge` 必須前提の記述が残っていない
- [x] 変更は最小差分に留まっている
- [x] Issue #31 の受け入れ条件を満たしている