### PR TITLE
release: develop を main へ反映 (2026-02-17)

### DIFF
--- a/.ai/workflow.md
+++ b/.ai/workflow.md
@@ -139,7 +139,7 @@
   - `AI.md と .ai の必読を読み込み、計画準備状態へ入って（/plan 相当）`
   - `Issue #7 を primary_issue として .context/issue_scope.json を更新して（/pick 相当）`
   - `Issue #7 のレビューコメントを検証し、採用指摘のみ修正してIssueへ結果コメントして（/rv 相当）`
-  - `develop から main へのリリースPRを作成（必要ならマージ）して、.context の pr_number/pr_url を更新して（/mtm 相当）`
+  - `develop から main へのリリースPRを作成して通常はそのままマージし、必要なら --no-merge で作成のみ実行して、.context の pr_number/pr_url を更新して（/mtm 相当）`
   - `git add -A 後に確認付きでコミット候補を提示して（/commit 相当）`
   - `git add -A 後に最初の候補で即コミットして（/commit! 相当）`
 

--- a/.claude/commands/merge-to-main.md
+++ b/.claude/commands/merge-to-main.md
@@ -2,7 +2,7 @@
 title: "main反映PRタスク"
 read_only: false
 type: "command"
-argument-hint: "[--merge] [release-label]"
+argument-hint: "[--no-merge] [release-label]"
 ---
 
 # main反映PR作成（/merge-to-main）
@@ -22,14 +22,15 @@ argument-hint: "[--merge] [release-label]"
    - タイトル例: `release: develop を main へ反映 (<YYYY-MM-DD>)`
    - 本文には、目的・影響範囲・確認手順・未実施項目を記載する。
 6. Open PRがある場合は、そのPRを再利用する（重複PRは作成しない）。
-7. `--merge` が明示された場合のみ、チェック成功を確認してPRをマージする。
+7. `--no-merge` が明示されていない場合は、チェック成功を確認してPRをマージする。
 8. `.context/issue_scope.json` を使う運用の場合は、`pr_number` / `pr_url` / `updated_at` をロック付きで更新する。
 9. 結果を日本語で報告する（作成/再利用したPR URL、マージ有無、未実施項目）。
 
 ## ルール
 
-- デフォルト動作は「PR作成または再利用まで」。自動マージはしない。
+- デフォルト動作は「PR作成または再利用後にマージまで実行」。
+- `--no-merge` 指定時のみ、PR作成または再利用までで止める。
 - `main` への直接push/直接マージは行わない。
-- `--merge` 指定時でも、必須チェック未通過ならマージしない。
+- 必須チェック未通過ならマージしない。
 - 既存のOpenな `develop -> main` PRがある場合は、それを優先して使う。
 - コンフリクトがある場合は自動解消しない。`develop` 側で解消してから同一PRを更新する。

--- a/.claude/commands/mtm.md
+++ b/.claude/commands/mtm.md
@@ -2,7 +2,7 @@
 title: "main反映PRタスク"
 read_only: false
 type: "command"
-argument-hint: "[--merge] [release-label]"
+argument-hint: "[--no-merge] [release-label]"
 ---
 
 # main反映PR作成（/mtm）
@@ -16,5 +16,5 @@ argument-hint: "[--merge] [release-label]"
 
 - `base=main` / `head=develop` のPR作成（または既存PR再利用）を行う。
 - `develop -> main` 反映時は本コマンド（または `/merge-to-main`）を必須で利用する。
-- `--merge` がない限り、PRは作成/更新のみで止める。
+- `--no-merge` がない限り、PRは作成/更新後にマージまで行う。
 - `.context/issue_scope.json` を使う場合は `pr_number` / `pr_url` を更新する。

--- a/AI.md
+++ b/AI.md
@@ -19,7 +19,7 @@ Conductorでの基本的な進め方は、次の順番です。
 3. レビュー依頼（対象Issue番号を明記し、レビュー結果はIssueコメントに記載）
 4. `/review-verify <issue-number>` または `/rv <issue-number>` で指摘対応し、修正結果をIssueコメントに記載（引数なし時は `.context` の `primary_issue` + `active_related_issues` を参照）
 5. 小さなPRを順次適用
-6. リリース時は `/merge-to-main` または `/mtm` で `develop -> main` のPRを作成（必須手順）
+6. リリース時は `/merge-to-main` または `/mtm` で `develop -> main` のPRを作成し、通常はそのままマージ（必須手順）
 7. 必要なら `/commit` / `/c` または `/commit!` / `/c!`
 
 ### コマンド説明
@@ -29,7 +29,7 @@ Conductorでの基本的な進め方は、次の順番です。
 - `/pick <primary-issue> [related-issues...]` または `/p <primary-issue> [related-issues...]`: `schema_version: 2` の `.context/issue_scope.json` に対象Issueを固定します（任意）。related issue を扱う場合は `active_related_issues` を `reserved` で確保し、`owner` / `reserved_at`（必要なら `expires_at`）を記録します。
 - レビュー依頼: 明示コマンドは不要です。差分レビューを依頼します。
 - `/review-verify <issue-number>` または `/rv <issue-number>`: 対象Issueのレビューコメントを読み込み、採用された指摘のみ修正します。Issue連携した場合は修正結果コメントをIssueへ追記します。引数なし時は `.context/issue_scope.json` の `primary_issue` と `active_related_issues`（`in_progress` / `ready_for_close`）を対象にします。
-- `/merge-to-main [--merge] [release-label]` または `/mtm [--merge] [release-label]`: `develop -> main` 反映時の必須手順です。`base=main` / `head=develop` のリリースPRを作成（既存Open PRがあれば再利用）します。`--merge` 指定時のみマージまで実行します。詳細は `.claude/commands/merge-to-main.md` を参照します。
+- `/merge-to-main [--no-merge] [release-label]` または `/mtm [--no-merge] [release-label]`: `develop -> main` 反映時の必須手順です。`base=main` / `head=develop` のリリースPRを作成（既存Open PRがあれば再利用）し、デフォルトでマージまで実行します。PR作成/再利用のみで止める場合は `--no-merge` を指定します。詳細は `.claude/commands/merge-to-main.md` を参照します。
 - `/commit` または `/c`: 確認付きコミットです。候補メッセージ確認後にコミットします。
 - `/commit!` または `/c!`: 確認なしで即時コミットします。
 
@@ -41,7 +41,7 @@ Conductorでの基本的な進め方は、次の順番です。
   - `AI.md と .ai の必読を読み込み、計画準備状態へ入って（/plan 相当）`
   - `Issue #7 を primary_issue として .context/issue_scope.json を更新して（/pick 相当）`
   - `Issue #7 のレビューコメントを検証し、採用指摘のみ修正してIssueへ結果コメントして（/rv 相当）`
-  - `develop から main へのリリースPRを作成し、.context の pr_number/pr_url を更新して（/mtm 相当）`
+  - `develop から main へのリリースPRを作成して通常はそのままマージし、.context の pr_number/pr_url を更新して（/mtm 相当）`
   - `git add -A 後に確認付きコミット候補を出して（/commit 相当）`
 
 ### レビュー連携の要点


### PR DESCRIPTION
## 概要
`develop` ブランチの差分を `main` へ反映するリリースPRです。

## 変更内容
- `origin/main...origin/develop` の比較で `develop` 側の未反映コミットを `main` に取り込み
- 既存の `develop -> main` Open PR はなかったため新規作成

## テスト手順
実行コマンドと結果:
- `git fetch origin main develop --prune`
  - 結果: 取得成功
- `git rev-list --left-right --count origin/main...origin/develop`
  - 結果: `12 1`（`develop` 側に 1 commit の未反映あり）
- `git log --oneline origin/main..origin/develop | head -n 20`
  - 結果: `5bdd1c7 📝 docs: mtmのデフォルト自動マージ仕様を反映 (#32)`

## 影響範囲
- `develop` と `main` のブランチ差分全体

## チェックリスト
- [x] `develop -> main` Open PR の重複がないことを確認
- [x] 差分コミットの存在を確認
- [ ] PRマージ後の同期確認（この後実施）

未実施項目:
- CI 実行結果の追加確認
  - 理由: PR作成直後のため、必要に応じてマージ前に確認
